### PR TITLE
Revert "fix(clipboard): tmux clipboard depends on $TMUX #31268"

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -255,7 +255,7 @@ function! provider#clipboard#Executable() abort
     return s:set_clip()
   elseif executable('termux-clipboard-set')
     return s:set_termux()
-  elseif executable('tmux') && (!empty($TMUX) || 0 == jobwait([jobstart(['tmux', 'list-buffers'])], 2000)[0])
+  elseif !empty($TMUX) && executable('tmux')
     return s:set_tmux()
   elseif get(get(g:, 'termfeatures', {}), 'osc52') && &clipboard ==# ''
     " Don't use OSC 52 when 'clipboard' is set. It can be slow and cause a lot


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

As mentioned in https://github.com/neovim/neovim/issues/33986#issuecomment-2901204879 this default serves an uncommon case,  and breaks usage of osc52, which is a more universal way of handling clipboards over ssh

One example is @gou4shi1 that uses tmux simply for long-running tasks, but has a kitty terminal that supports osc52

In my case i sometimes use shared user accounts, where a tmux session might not even be made by me